### PR TITLE
i9300: Fix broken AIF2 logic

### DIFF
--- a/audio/audio_hw.h
+++ b/audio/audio_hw.h
@@ -142,8 +142,6 @@ struct route_setting default_input[] = {
 struct route_setting default_input_disable[] = {
     { .ctl_name = "Main Mic Switch", .intval = 0, },
     { .ctl_name = "MIXINL IN1L Switch", .intval = 0, },
-    { .ctl_name = "AIF2DACL Source", .intval = 0, },
-    { .ctl_name = "AIF2DACR Source", .intval = 1, },
     { .ctl_name = NULL, },
 };
 
@@ -191,8 +189,6 @@ struct route_setting headset_input[] = {
 struct route_setting headset_input_disable[] = {
     { .ctl_name = "Headset Mic Switch", .intval = 0, },
     { .ctl_name = "MIXINL IN2L Switch", .intval = 0, },
-    { .ctl_name = "AIF2DACL Source", .intval = 0, },
-    { .ctl_name = "AIF2DACR Source", .intval = 1, },
     { .ctl_name = NULL, },
 };
 


### PR DESCRIPTION
We have only one analog source and one speaker, do not use right (mute) channel for AIF2