### PR TITLE
fstab: remove discard mount option

### DIFF
--- a/rootdir/fstab.smdk4x12
+++ b/rootdir/fstab.smdk4x12
@@ -6,7 +6,7 @@
 /dev/block/mmcblk0p9		/system			ext4		ro,noatime		wait
 /dev/block/mmcblk0p8		/cache			ext4		noatime,nosuid,nodev,journal_async_commit,errors=panic		wait
 /dev/block/mmcblk0p10		/preload		ext4		noatime,nosuid,nodev,journal_async_commit		wait
-/dev/block/mmcblk0p12		/data			ext4		noatime,nosuid,nodev,discard,noauto_da_alloc,journal_async_commit,errors=panic		wait,check,encryptable=footer
+/dev/block/mmcblk0p12		/data			ext4		noatime,nosuid,nodev,noauto_da_alloc,journal_async_commit,errors=panic		wait,check,encryptable=footer
 
 # vold-managed volumes ("block device" is actually a sysfs devpath)
 /devices/platform/s3c-sdhci.2/mmc_host*		auto		auto		defaults		voldmanaged=sdcard1:auto,noemulatedsd


### PR DESCRIPTION
  * the system handles trimming by itself

Change-Id: I2a747e97a5fcc1a3d051329c83249784e90e063c
Signed-off-by: Alexander Martinz <eviscerationls@gmail.com>