### PR TITLE
i9300: mqanelements should actually be 4

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -5,6 +5,5 @@
 dalvik.vm.dexopt-data-only=1
 rild.libpath=/system/lib/ril-wrapper.so
 rild.libargs=-d /dev/ttyS0
-ro.ril.telephony.mqanelements=5
 ro.sf.lcd_density=320
 ro.lcd_min_brightness=20


### PR DESCRIPTION
fixes manual network selection

Change-Id: I516917a816a202020d41b8621d7ea07464c73f1f
